### PR TITLE
Update 1.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
-  skip: True  # [py<310]
+  skip: True  # [py<38]
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,7 @@ requirements:
 test:
   imports:
     - opentelemetry
-    - opentelemetry.context
-
+    - opentelemetry.propagators.b3
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-propagator-b3" %}
-{% set version = "1.28.2" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,26 +7,28 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_propagator_b3-{{ version }}.tar.gz
-  sha256: 0e0b204e8eee3042c0d9fb3cd6f1a75b2a4af9b0a539a18ad510b453d563f876
+  sha256: aa05f951099f7b402139de64aa9169dc692e02741ee95ad70a1454a6d4c76c81
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  skip: True  # [py<310]
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
   run:
-    - python >=3.7
+    - python
     - deprecated >=1.2.6
     - opentelemetry-api ~=1.3
 
 test:
   imports:
-    - opentelemetry.propagators.b3
+    - opentelemetry
+    - opentelemetry.context
+
   commands:
     - pip check
   requires:
@@ -37,7 +39,11 @@ about:
   summary: OpenTelemetry B3 Propagator
   license: Apache-2.0
   license_file: LICENSE
-  description: This library provides a propagator for the B3 format
+  license_family: Apache
+  description: |
+    This library provides a propagator for the B3 format
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/master/propagator/opentelemetry-propagator-b3
+  doc_url: https://github.com/open-telemetry/opentelemetry-python/blob/main/propagator/opentelemetry-propagator-b3/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆`Opentelemetry-propagator-b3 v1.26.0`☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2429) 
[Upstream](https://github.com/open-telemetry/opentelemetry-python/tree/v1.26.0/propagator/opentelemetry-propagator-b3)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Updated `tests`
