### PR TITLE
opentelemetry-propagator-b3 1.38.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   skip: true  # [py<39]
   number: 0
+  entry_points:
+    - b3 = opentelemetry.propagators.b3:B3SingleFormat
+    - b3multi = opentelemetry.propagators.b3:B3MultiFormat
 
 requirements:
   host:
@@ -21,7 +24,7 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api >=1.3,<2.dev0
+    - opentelemetry-api >=1.3,<2
     - typing_extensions >=4.5.0
 
 test:
@@ -32,6 +35,10 @@ test:
     - tests/
   commands:
     - pip check
+    - python -c "from opentelemetry.propagators.b3 import B3SingleFormat; B3SingleFormat()"
+    - python -c "from opentelemetry.propagators.b3 import B3MultiFormat; B3MultiFormat()"
+    - python -c "import pkg_resources; assert any(ep.name == 'b3' for ep in pkg_resources.iter_entry_points('opentelemetry_propagator'))"
+    - python -c "import pkg_resources; assert any(ep.name == 'b3multi' for ep in pkg_resources.iter_entry_points('opentelemetry_propagator'))"
     - pytest -v tests
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "opentelemetry-propagator-b3" %}
-{% set version = "1.30.0" %}
+{% set version = "1.38.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_propagator_b3-{{ version }}.tar.gz
-  sha256: d3ac7b90f0bdb0da20e57e7659555a2cb82b8229218b57a50686633d97d4cc2d
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 16f42fa7a30a41dd710c67832e63985def8f6eddd8425becb832ba20b40595b5
 
 build:
-  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
-  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  skip: true  # [py<39]
   number: 0
 
 requirements:
@@ -21,26 +21,32 @@ requirements:
     - hatchling
   run:
     - python
-    - deprecated >=1.2.6
-    - opentelemetry-api >=1.3,<2.0.0.dev0
+    - opentelemetry-api >=1.3,<2.dev0
+    - typing_extensions >=4.5.0
+
 test:
   imports:
     - opentelemetry
     - opentelemetry.propagators.b3
+  source_files:
+    - tests/
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - opentelemetry-sdk
+    - pytest =7.4.4
 
 about:
-  home: https://github.com/open-telemetry/opentelemetry-python/tree/master/propagator/opentelemetry-propagator-b3
+  home: https://github.com/open-telemetry/opentelemetry-python/tree/main/propagator/opentelemetry-propagator-b3
   summary: OpenTelemetry B3 Propagator
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
   description: |
     This library provides a propagator for the B3 format
-  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/master/propagator/opentelemetry-propagator-b3
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/propagator/opentelemetry-propagator-b3
   doc_url: https://github.com/open-telemetry/opentelemetry-python/blob/main/propagator/opentelemetry-propagator-b3/README.rst
 
 extra:


### PR DESCRIPTION
opentelemetry-propagator-b3 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10026]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-propagator-b3-feedstock
- pypi:           https://pypi.org/project/opentelemetry-propagator-b3/1.38.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-propagator-b3/1.38.0

### Explanation of changes:

- new version number
- add testing


[PKG-10026]: https://anaconda.atlassian.net/browse/PKG-10026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ